### PR TITLE
install snapshot crd

### DIFF
--- a/helm/csi-driver-nfs/templates/crd-csi-snapshot.yaml
+++ b/helm/csi-driver-nfs/templates/crd-csi-snapshot.yaml
@@ -1,4 +1,3 @@
-{{- if and .Values.externalSnapshotter.enabled .Values.externalSnapshotter.customResourceDefinitions.enabled -}}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -840,4 +839,3 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
-{{- end -}}

--- a/sync/patches/crd-csi-snapshot/_templates___crd-csi-snapshot.yaml.patch
+++ b/sync/patches/crd-csi-snapshot/_templates___crd-csi-snapshot.yaml.patch
@@ -1,0 +1,14 @@
+diff --git a/helm/csi-driver-nfs/templates/crd-csi-snapshot.yaml b/helm/csi-driver-nfs/templates/crd-csi-snapshot.yaml
+index 7682b83..87b35b1 100644
+--- a/helm/csi-driver-nfs/templates/crd-csi-snapshot.yaml
++++ b/helm/csi-driver-nfs/templates/crd-csi-snapshot.yaml
+@@ -1,4 +1,3 @@
+-{{- if and .Values.externalSnapshotter.enabled .Values.externalSnapshotter.customResourceDefinitions.enabled -}}
+ ---
+ apiVersion: apiextensions.k8s.io/v1
+ kind: CustomResourceDefinition
+@@ -840,4 +839,3 @@ status:
+     plural: ""
+   conditions: []
+   storedVersions: []
+-{{- end -}}

--- a/sync/patches/crd-csi-snapshot/patch.sh
+++ b/sync/patches/crd-csi-snapshot/patch.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+repo_dir=$(git rev-parse --show-toplevel) ; readonly repo_dir
+script_dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd ) ; readonly script_dir
+
+cd "${repo_dir}"
+
+readonly script_dir_rel=".${script_dir#"${repo_dir}"}"
+
+set -x
+git apply "${script_dir_rel}/_templates___crd-csi-snapshot.yaml.patch"
+
+{ set +x; } 2>/dev/null

--- a/sync/sync.sh
+++ b/sync/sync.sh
@@ -17,6 +17,7 @@ helm dependency update helm/csi-driver-nfs/
 ./sync/patches/values/patch.sh
 ./sync/patches/chart/patch.sh
 ./sync/patches/helpers/patch.sh
+./sync/patches/crd-csi-snapshot/patch.sh
 
 # generate schema
 set -x


### PR DESCRIPTION
This adds a patch in order to install snapshot crds regardless of whether external snapshotter is enabled.
This prevents the snapshot container from erroring. (https://github.com/kubernetes-csi/csi-driver-nfs/issues/722)

<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

<!--
MODIFY THIS AFTER your new app repo is in https://github.com/giantswarm/github
@team-halo-engineers will be automatically requested for review once
this PR has been submitted. (But not for drafts)
-->

This PR:

- adds/changes/removes etc

### Testing

Description on how csi-driver-nfs can be tested.

- [ ] fresh install works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM
- [ ] upgrade from previous version works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM

#### Other testing

Description of features to additionally test for csi-driver-nfs installations.

- [ ] check reconciliation of existing resources after upgrading
- [ ] X still works after upgrade
- [ ] Y is installed correctly

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
